### PR TITLE
Home Assistant MQTT integration

### DIFF
--- a/config.h
+++ b/config.h
@@ -9,6 +9,7 @@
 #define DEBUG 	// Output to serial port
 //#define WIFI   	// use WiFi
 //#define MQTT 		// log sensor data to M/QTT broker
+//#define HASSIO_MQTT  // And, if MQTT enabled, with Home Assiatant too?
 //#define INFLUX	// Log data to InfluxDB server
 
 // Step 2: Set battery size if applicable
@@ -48,7 +49,7 @@
 // rotation 1 orients the display so the wiring is at the top
 // rotation of 3 flips it so the wiring is at the bottom
 // 200x200 resolution
-const int DISPLAY_ROTATION = 3;
+#define DISPLAY_ROTATION 3
 
 // SCD40 sample timing
 #ifdef DEBUG
@@ -94,11 +95,19 @@ const int   daylightOffset_sec = 0;
 	// e.g. #define MQTT_PUB_TOPIC1		"sircoolio/feeds/pocket-office.temperature"
 
 	// structure: site/room/device/data	
-	#define MQTT_PUB_TOPIC1		"7828/demo/rco2/temperature"
-	#define MQTT_PUB_TOPIC2		"7828/demo/rco2/humidity"
-	#define MQTT_PUB_TOPIC3		"7828/demo/rco2/co2"
-	#define MQTT_PUB_TOPIC5		"7828/demo/rco2/battery-voltage"
-	#define MQTT_PUB_TOPIC6		"7828/demo/rco2/rssi"
+	#define MQTT_PUB_TEMPF		 "7828/demo/rco2/temperature"
+	#define MQTT_PUB_HUMIDITY  "7828/demo/rco2/humidity"
+	#define MQTT_PUB_CO2	     "7828/demo/rco2/co2"
+	#define MQTT_PUB_BATTV		 "7828/demo/rco2/battery-voltage"
+	#define MQTT_PUB_RSSI	     "7828/demo/rco2/rssi"=
+
+  // Additional (optional) topics if integrating with Home Assistant
+  #ifdef HASSIO_MQTT
+    // Home Assistant entity configuration & state (values) topics. NOTE: MUST MATCH value
+    // used in Home Assistant MQTT configuration file (configuration.yaml). See 
+    // hassio_mqtt.cpp for details.
+    #define MQTT_HASSIO_STATE   "homeassistant/sensor/rco2-1/state"
+  #endif
 #endif
 
 #ifdef INFLUX

--- a/hassio_mqtt.cpp
+++ b/hassio_mqtt.cpp
@@ -1,0 +1,132 @@
+/*
+ * Additional routines for use in an MQTT-enabled environment with Home Assistant, allowing
+ * sensor readings to be reported to Home Assistant.   
+ * 
+ * Requires the following addition to configuration.yaml for Home Assistant, with the
+ * state topic declared to match MQTT_HASSIO_STATE as defined in config.h. Also, Unique IDs, 
+ * which enable additional UI customization features for the sensors in Home Assistant,
+ * can be generated here: https://www.uuidgenerator.net/version1.
+
+   mqtt:
+    sensor:
+     - name: "Temperature"
+      device_class: "temperature"
+      state_topic: "homeassistant/sensor/rco2-1/state"
+      unit_of_measurement: "°F"
+      unique_id: "-- GENERATE A UUID TO USE HERE --"
+      value_template: "{{ value_json.temperature }}"
+    - name: "Humidity"
+      device_class: "humidity"
+      state_topic: "homeassistant/sensor/rco2-1/state"
+      unit_of_measurement: "%"
+      unique_id: "-- GENERATE A UUID TO USE HERE --"
+      value_template: "{{ value_json.humidity }}"
+    - name: "CO2"
+      device_class: "carbon_dioxide"
+      state_topic: "homeassistant/sensor/rco2-1/state"
+      unit_of_measurement: "ppm"
+      unique_id: "-- GENERATE A UUID TO USE HERE --"
+      value_template: "{{ value_json.co2 }}"
+ */
+
+#include "Arduino.h"
+
+// hardware and internet configuration parameters
+#include "config.h"
+// private credentials for network, MQTT, weather provider
+#include "secrets.h"
+
+// Shared helper function
+extern void debugMessage(String messageText);
+
+#if defined MQTT && defined HASSIO_MQTT
+    // MQTT setup
+    #include <Adafruit_MQTT.h>
+    #include <Adafruit_MQTT_Client.h>
+    #include <ArduinoJson.h>
+    extern Adafruit_MQTT_Client aq_mqtt;
+
+    // The code below attempts to enable MQTT auto-discovery for Home Assistant,
+    // but so far doesn't work to do that.  Instead this function isn't called from
+    // post_mqtt(), and manual sensor configuration is enabled in the Home Assistant
+    // configuration file.  See hassio_mqtt.cpp for more details.
+    #define TCONFIG_TOPIC "homeassistant/sensor/rco2-1T/config"
+    #define HCONFIG_TOPIC "homeassistant/sensor/rco2-1H/config"
+    #define CCONFIG_TOPIC "homeassistant/sensor/rco2-1C/config"
+
+    void hassio_mqtt_setup() {
+        const int capacity = JSON_OBJECT_SIZE(5);
+        StaticJsonDocument<capacity> doc;
+
+        // Declare buffer to hold serialized object
+        char output[1024];
+
+        // Create MQTT publish objects for the config channels
+        Adafruit_MQTT_Publish tconfigPub = Adafruit_MQTT_Publish(&aq_mqtt,TCONFIG_TOPIC);
+        Adafruit_MQTT_Publish hconfigPub = Adafruit_MQTT_Publish(&aq_mqtt,HCONFIG_TOPIC);
+        Adafruit_MQTT_Publish cconfigPub = Adafruit_MQTT_Publish(&aq_mqtt,CCONFIG_TOPIC);
+
+        debugMessage(String("Configuring RCO2 for Home Assistant MQTT auto-discovery"));
+        // Create config info for temperature sensor
+        doc["device_class"] = "temperature";
+        doc["name"] = "Temperature";
+        doc["state_topic"] = MQTT_HASSIO_STATE;
+        doc["unit_of_measurement"] = "°F";
+        doc["value_template"] = "{{ value_json.temperature}}";
+
+        serializeJson(doc,output);
+        // Publish temperature config to its topic (TCONFIG_TOPIC) as a retained message
+        debugMessage(output);
+        tconfigPub.publish(output,true);
+
+        // Reset config data for humidity sensor
+        doc["device_class"] = "humidity";
+        doc["name"] = "Humidity";
+        doc["state_topic"] = MQTT_HASSIO_STATE;
+        doc["unit_of_measurement"] = "%";
+        doc["value_template"] = "{{ value_json.humidity}}";
+
+        serializeJson(doc,output);
+        // Publish humidity config to its topic (HCONFIG_TOPIC) as a retained message
+        debugMessage(output);
+        hconfigPub.publish(output,true);
+
+        // Reset config data for co2 sensor
+        doc["device_class"] = "carbon_dioxide";
+        doc["name"] = "CO2";
+        doc["state_topic"] = MQTT_HASSIO_STATE;
+        doc["unit_of_measurement"] = "ppm";
+        doc["value_template"] = "{{ value_json.co2}}";
+
+        serializeJson(doc,output);
+        // Publish humidity config to its topic (CCONFIG_TOPIC) as a retained message
+        debugMessage(output);
+        cconfigPub.publish(output,true);
+    }
+
+    // Called to publish sensor readings as a JSON payload, as part of overall MQTT
+    // publishing as implemented in post_mqtt().  Should only be invoked if 
+    // Home Assistant MQTT integration is enabled in config.h.
+    // Note that it depends on the value of the state topic matching what's in Home
+    // Assistant's configuration file (configuration.yaml).
+    void hassio_mqtt_publish(uint16_t co2, float tempF, float humidity) {
+        const int capacity = JSON_OBJECT_SIZE(3);
+        StaticJsonDocument<capacity> doc;
+
+        // Declare buffer to hold serialized object
+        char output[1024];
+        
+        Adafruit_MQTT_Publish rco2StatePub = Adafruit_MQTT_Publish(&aq_mqtt,MQTT_HASSIO_STATE);
+
+        debugMessage("Publishing RCO2 values to Home Assistant via MQTT (topic below)");
+        debugMessage(MQTT_HASSIO_STATE);
+        doc["temperature"] = tempF;
+        doc["humidity"] = humidity;
+        doc["co2"] = co2;
+
+        serializeJson(doc,output);
+        // Publish state info to its topic (MQTT_HASSIO_STATE)
+        debugMessage(output);
+        rco2StatePub.publish(output);
+    }
+#endif

--- a/secrets_template.h
+++ b/secrets_template.h
@@ -9,8 +9,10 @@
 // #define SITE_ALTITUDE	263 // calibrate SCD40, in meters above sea level; example is Pasadena, CA
 
 // #ifdef MQTT
+//  #define MQTT BROKER    "mqtt.hostname.local or IP address"
 // 	#define MQTT_PORT  			port_number	// use 8883 for SSL
-// 	#define MQTT_USER			"key_value"
+// 	#define MQTT_USER			 "key_value"
+//  #define MQTT_PASSWORD  "key_value"
 // #endif
 
 // #ifdef INFLUX


### PR DESCRIPTION
Added support for Home Assistant integration via MQTT, when MQTT is enabled overall in config.h.  This means the following:

- Adds a new config.h #define to enable Home Assistant MQTT integration (#define HASSIO_MQTT)
- Added to config.h a "state" topic for HA MQTT use, with temperature, humidity, and CO2 reported as a single JSON object as messages on that topic.  (This matches how Home Assistant wants MQTT devices integrated)
- Added code to publish SCD 40 sensor values to that state topic, but in a separate hassio_mqtt.cpp file so it's easier to isolate and maintain that code plus conditionally compile it in when HASSIO_MQTT is defined
- Called the HA MQTT publish function (hassio_mqtt_publish()) from within the existing post_mqtt() routine, with appropriate guard #defines 
- Tweaked our standard MQTT topic #defines so they reflect what that topic is reporting, rather than just being sequentially numbered.  (This change is in config.h and post_mqtt.cpp)

Note that for Home Assistant UI integration to work the HA configuration must be modified to define the SCD40 sensor and its properties.  This involves editing the HA installation's configuration.yaml file.   An example of how to do that is provided in a comment at the beginning of hassio_mqtt.cpp so developers could copy/paste that example to streamline installation, and additional details (e.g. modifying configuration.yaml) are in Home Assistant documentation.  

Proper Home Assistant UI integration depends on each sensor having a unique ID (so HA can support users giving sensor data a descriptive name in the UI, for example).  I've implemented that by allowing custom-generated UUIDs to be associated with each sensor.  The example configuration info provided in hassio_mqtt.cpp provides a placeholder for those UUIDs along with a link to a public site where they can be generated.

The updated code also includes a function that attempts to do MQTT auto-discovery with Home Assistant, though I've not yet been able to get that to work.  For now that function is disabled though I'll continue to experiment.  Auto-discovery would avoid needing to modify configuration.yaml to manually add sensor definition info, but for now manual configuration works fine.

All changes/features have been tested on my realtime_co2 device with Home Assistant installed on a Raspberry Pi 4.  That Home Assistant installation also includes the Mosquitto MQTT broker add-on, installed and configured as documented with Home Assistant.