### PR TITLE
Add dynamically generated data nomenclature for back end services

### DIFF
--- a/config.h
+++ b/config.h
@@ -116,4 +116,9 @@ const int   daylightOffset_sec = 0;
   #define INFLUX_DEV_MEASUREMENT "device"   // Used for logging AQI device data (e.g. battery)
 #endif
 
+#ifdef DWEET
+  #define DWEET_HOST "dweet.io"   // Typically dweet.io
+  #define DWEET_DEVICE "realtime_co2"     // dbryant custom name
+#endif
+
 #endif // #ifdef CONFIG_H

--- a/config.h
+++ b/config.h
@@ -4,6 +4,8 @@
 
   See README.md for target information and revision history
 */
+#ifndef CONFIG_H
+#define CONFIG_H
 
 // Step 1: Set conditional compile flags
 #define DEBUG 	// Output to serial port
@@ -12,7 +14,17 @@
 //#define HASSIO_MQTT  // And, if MQTT enabled, with Home Assistant too?
 #define INFLUX	// Log data to InfluxDB server
 
-// Step 2: Set battery size if applicable
+// Step 2: Set key device and installation configuration parameters.  These are used
+// widely throughout the code to properly identify the device and generate important
+// operating elements like MQTT topics, InfluxDB data tags (metadata).  Should be
+// customized to match the target installation. Values here are examples.
+#define DEVICE           "realtime_co2"
+#define DEVICE_SITE      "beachhouse"
+#define DEVICE_LOCATION  "outdoor"
+#define DEVICE_ROOM      "boatdock"
+#define DEVICE_ID        "Unique_device_ID"
+
+// Step 3: Set battery size if applicable
 // based on a settings curve in the LC709203F datasheet
 // #define BATTERY_APA 0x08 // 100mAH
 // #define BATTERY_APA 0x0B // 200mAH
@@ -39,8 +51,15 @@ const float batteryMinVoltage	= 3.2; 	// what we regard as an empty battery
 	#define VBATPIN A13
 #endif
 
-// rotation 1 orients the display so the wiring is at the top
-// rotation of 3 flips it so the wiring is at the bottom
+// Sleep time in seconds if hardware error occurs
+#define HARDWARE_ERROR_INTERVAL 10
+
+#define CONNECT_ATTEMPT_LIMIT	3 // max connection attempts to internet services
+#define CONNECT_ATTEMPT_INTERVAL 10 // seconds between internet service connect attempts
+
+// Allow for adjustable screen as needed for physical packaging. 
+// Rotation 1 orients the display so the wiring is at the top.
+// A rotation of 3 flips it so the wiring is at the bottom
 #define DISPLAY_ROTATION 3
 
 // SCD40 sample timing
@@ -57,15 +76,11 @@ const float batteryMinVoltage	= 3.2; 	// what we regard as an empty battery
 // nvStorageRead and nvStorageWrite currently don't work if >10
 const int co2MaxStoredSamples = 10;
 
-// Sleep time in seconds if hardware error occurs
-#define HARDWARE_ERROR_INTERVAL 10
-
 const String co2Labels[5]={"Good", "OK", "So-So", "Poor", "Bad"};
 // used in aq_network.cpp
 const String weekDays[7] = { "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" };
 
 // NTP time configuration
-
 //https://cplusplus.com/reference/ctime/tm/
 
 #define ntpServer "pool.ntp.org"
@@ -75,49 +90,30 @@ const long  gmtOffset_sec = -28800; // PST
 const int   daylightOffset_sec = 0;
 // const int   daylightOffset_sec = 3600; // US DT
 
-// set client ID; used by mqtt and wifi
-#define CLIENT_ID "RCO2"
-
-#define CONNECT_ATTEMPT_LIMIT	3 // max connection attempts to internet services
-#define CONNECT_ATTEMPT_INTERVAL 10 // seconds between internet service connect attempts
-
 #ifdef MQTT
 	// Adafruit I/O
 	// structure: username/feeds/groupname.feedname or username/feeds/feedname
 	// e.g. #define MQTT_PUB_TOPIC1		"sircoolio/feeds/pocket-office.temperature"
 
 	// structure: site/room/device/data	
-	#define MQTT_PUB_TEMPF			"7828/demo/rco2/temperature"
-	#define MQTT_PUB_HUMIDITY		"7828/demo/rco2/humidity"
-	#define MQTT_PUB_CO2				"7828/demo/rco2/co2"
-	#define MQTT_PUB_BATTVOLT		"7828/demo/rco2/battery-voltage"
-	#define MQTT_PUB_RSSI				"7828/demo/rco2/rssi"
+	// #define MQTT_PUB_TEMPF			"7828/demo/rco2/temperature"
+	// #define MQTT_PUB_HUMIDITY		"7828/demo/rco2/humidity"
+	// #define MQTT_PUB_CO2				"7828/demo/rco2/co2"
+	// #define MQTT_PUB_BATTVOLT		"7828/demo/rco2/battery-voltage"
+	// #define MQTT_PUB_RSSI				"7828/demo/rco2/rssi"
 
   // Additional (optional) topics if integrating with Home Assistant
   #ifdef HASSIO_MQTT
     // Home Assistant entity configuration & state (values) topics. NOTE: MUST MATCH value
     // used in Home Assistant MQTT configuration file (configuration.yaml). See 
     // hassio_mqtt.cpp for details.
-    #define MQTT_HASSIO_STATE   "homeassistant/sensor/rco2-1/state"
+    // #define MQTT_HASSIO_STATE   "homeassistant/sensor/rco2-1/state"
   #endif
 #endif
 
 #ifdef INFLUX
   #define INFLUX_ENV_MEASUREMENT "weather"  // Used for environmental sensor data
   #define INFLUX_DEV_MEASUREMENT "device"   // Used for logging AQI device data (e.g. battery)
-  
-	// Standard set of tag values used for each sensor data point stored to InfluxDB.  Reuses
-  // CLIENT_ID as defined anove here in config.h as well as device location (e.g., room in 
-  // the house) and site (indoors vs. outdoors, typically).
-
-	// #define DEVICE_LOCATION "test"
-	#define DEVICE_LOCATION "RCO2-demo"
-	//#define DEVICE_LOCATION "kitchen"
-	// #define DEVICE_LOCATION "cellar"
-	// #define DEVICE_LOCATION "lab-office"
-	// #define DEVICE_LOCATION "master bedroom"
-  // #define DEVICE_LOCATION "pocket-office"
-
-	#define DEVICE_SITE "indoor"
-	#define DEVICE_TYPE "air quality"
 #endif
+
+#endif // #ifdef CONFIG_H

--- a/data.h
+++ b/data.h
@@ -7,7 +7,8 @@
 // to the important data tag values set in config.h, which are
 // expected to be customized there on a per installation basis.  These,
 // however, should not be changed.
-o DEVICE_ID in config.h
+#define TAG_KEY_DEVICE     "device"     // Maps to DEVICE in config.h
+#define TAG_KEY_DEVICE_ID  "device_id"  // Maps to DEVICE_ID in config.h
 #define TAG_KEY_SITE       "site"       // Maps to SITE in config.h
 #define TAG_KEY_LOCATION   "location"   // Maps to LOCATION in config.h
 #define TAG_KEY_ROOM       "room"       // Maps to ROOM in config.h
@@ -19,8 +20,6 @@ o DEVICE_ID in config.h
 
 #define VALUE_KEY_TEMPERATURE   "temperature"
 #define VALUE_KEY_HUMIDITY      "humidity"
-#define TAG_KEY_DEVICE     "device"     // Maps to DEVICE in config.h
-#define TAG_KEY_DEVICE_ID  "device_id"  // Maps t
 #define VALUE_KEY_CO2           "co2"
 #define VALUE_KEY_PRESSURE      "pressure"
 #define VALUE_KEY_PM25          "pm25"

--- a/data.h
+++ b/data.h
@@ -1,0 +1,34 @@
+#ifndef DATA_H
+#define DATA_H
+
+// Define tag keys used to store important device attributes in
+// InfluxDB.  Will be used as InfluxDB tag keys for the associated
+// attribute.  Only relevant to InfluxDB (not MQTT).  Maps directly
+// to the important data tag values set in config.h, which are
+// expected to be customized there on a per installation basis.  These,
+// however, should not be changed.
+o DEVICE_ID in config.h
+#define TAG_KEY_SITE       "site"       // Maps to SITE in config.h
+#define TAG_KEY_LOCATION   "location"   // Maps to LOCATION in config.h
+#define TAG_KEY_ROOM       "room"       // Maps to ROOM in config.h
+
+// Defines value keys (strings) used for representing stored 
+// sensor and device data as key/value pairs in InfluxDB and
+// as parts of MQTT topics.  Must be unique, and must conform
+// to syntax required for field keys by InfluxDB and MQTT.
+
+#define VALUE_KEY_TEMPERATURE   "temperature"
+#define VALUE_KEY_HUMIDITY      "humidity"
+#define TAG_KEY_DEVICE     "device"     // Maps to DEVICE in config.h
+#define TAG_KEY_DEVICE_ID  "device_id"  // Maps t
+#define VALUE_KEY_CO2           "co2"
+#define VALUE_KEY_PRESSURE      "pressure"
+#define VALUE_KEY_PM25          "pm25"
+#define VALUE_KEY_AQI           "aqi"
+#define VALUE_KEY_BATTERY_VOLTS "battery_volts"
+#define VALUE_KEY_BATTERY_PCT   "battery_pct"
+#define VALUE_KEY_RSSI          "rssi"
+#define VALUE_KEY_NETWORK_IP    "network_ip"
+#define VALUE_KEY_VERSION       "version"
+
+#endif  // #ifdef DATA_H

--- a/hassio_mqtt.cpp
+++ b/hassio_mqtt.cpp
@@ -128,7 +128,7 @@ extern void debugMessage(String messageText, int messageLevel);
         Adafruit_MQTT_Publish rco2StatePub = Adafruit_MQTT_Publish(&aq_mqtt,topic.c_str());
 
         debugMessage("Publishing RCO2 values to Home Assistant via MQTT (topic below)",1);
-        debugMessage(MQTT_HASSIO_STATE,1);
+        debugMessage(topic,1);
 
         doc["temperature"] = tempF;
         doc["humidity"] = humidity;

--- a/hassio_mqtt.cpp
+++ b/hassio_mqtt.cpp
@@ -3,7 +3,7 @@
  * sensor readings to be reported to Home Assistant.   
  * 
  * Requires the following addition to configuration.yaml for Home Assistant, with the
- * state topic declared to match MQTT_HASSIO_STATE as defined in config.h. Also, Unique IDs, 
+ * state topic built from deployment parameters defined in config.h. Also, Unique IDs, 
  * which enable additional UI customization features for the sensors in Home Assistant,
  * can be generated here: https://www.uuidgenerator.net/version1.
 
@@ -11,19 +11,19 @@
     sensor:
      - name: "Temperature"
       device_class: "temperature"
-      state_topic: "homeassistant/sensor/rco2-1/state"
+      state_topic: "{DEVICE_SITE}/{DEVICE}/{DEVICE_ID}/state"
       unit_of_measurement: "°F"
       unique_id: "-- GENERATE A UUID TO USE HERE --"
       value_template: "{{ value_json.temperature }}"
     - name: "Humidity"
       device_class: "humidity"
-      state_topic: "homeassistant/sensor/rco2-1/state"
+      state_topic: "{DEVICE_SITE}/{DEVICE}/{DEVICE_ID}/state"
       unit_of_measurement: "%"
       unique_id: "-- GENERATE A UUID TO USE HERE --"
       value_template: "{{ value_json.humidity }}"
     - name: "CO2"
       device_class: "carbon_dioxide"
-      state_topic: "homeassistant/sensor/rco2-1/state"
+      state_topic: "{DEVICE_SITE}/{DEVICE}/{DEVICE_ID}/state"
       unit_of_measurement: "ppm"
       unique_id: "-- GENERATE A UUID TO USE HERE --"
       value_template: "{{ value_json.co2 }}"
@@ -60,6 +60,11 @@ extern void debugMessage(String messageText);
 
         // Declare buffer to hold serialized object
         char output[1024];
+        String topic;
+        // Generate the device state topic for Home Assistant using deployment parameters from
+        // config.h.  Note that this must match the state topic as specified in Home Assiatant's
+        // configuration file (configuration.yaml) for this device.
+        topic = String(DEVICE_SITE) + "/" + String(DEVICE) + "/" + String(DEVICE_ID) + "/state";
 
         // Create MQTT publish objects for the config channels
         Adafruit_MQTT_Publish tconfigPub = Adafruit_MQTT_Publish(&aq_mqtt,TCONFIG_TOPIC);
@@ -70,7 +75,7 @@ extern void debugMessage(String messageText);
         // Create config info for temperature sensor
         doc["device_class"] = "temperature";
         doc["name"] = "Temperature";
-        doc["state_topic"] = MQTT_HASSIO_STATE;
+        doc["state_topic"] = topic.c_str();
         doc["unit_of_measurement"] = "°F";
         doc["value_template"] = "{{ value_json.temperature}}";
 
@@ -82,7 +87,7 @@ extern void debugMessage(String messageText);
         // Reset config data for humidity sensor
         doc["device_class"] = "humidity";
         doc["name"] = "Humidity";
-        doc["state_topic"] = MQTT_HASSIO_STATE;
+        doc["state_topic"] = topic.c_str();
         doc["unit_of_measurement"] = "%";
         doc["value_template"] = "{{ value_json.humidity}}";
 
@@ -94,7 +99,7 @@ extern void debugMessage(String messageText);
         // Reset config data for co2 sensor
         doc["device_class"] = "carbon_dioxide";
         doc["name"] = "CO2";
-        doc["state_topic"] = MQTT_HASSIO_STATE;
+        doc["state_topic"] = topic.c_str();
         doc["unit_of_measurement"] = "ppm";
         doc["value_template"] = "{{ value_json.co2}}";
 
@@ -115,11 +120,15 @@ extern void debugMessage(String messageText);
 
         // Declare buffer to hold serialized object
         char output[1024];
-        
-        Adafruit_MQTT_Publish rco2StatePub = Adafruit_MQTT_Publish(&aq_mqtt,MQTT_HASSIO_STATE);
+        String topic;
+        // Generate the device state topic for Home Assistant using deployment parameters from
+        // config.h.  Note that this must match the state topic as specified in Home Assiatant's
+        // configuration file (configuration.yaml) for this device.
+        topic = String(DEVICE_SITE) + "/" + String(DEVICE) + "/" + String(DEVICE_ID) + "/state";
+        Adafruit_MQTT_Publish rco2StatePub = Adafruit_MQTT_Publish(&aq_mqtt,topic.c_str());
 
         debugMessage("Publishing RCO2 values to Home Assistant via MQTT (topic below)");
-        debugMessage(MQTT_HASSIO_STATE);
+        debugMessage(topic);
         doc["temperature"] = tempF;
         doc["humidity"] = humidity;
         doc["co2"] = co2;

--- a/post_dweet.cpp
+++ b/post_dweet.cpp
@@ -1,0 +1,77 @@
+#include "Arduino.h"
+
+// hardware and internet configuration parameters
+#include "config.h"
+// Overall data and metadata naming scheme
+#include "data.h"
+// private credentials for network, MQTT, weather provider
+#include "secrets.h"
+
+
+#ifdef DWEET
+#include <HTTPClient.h> 
+
+// Shared helper function we call here too...
+extern void debugMessage(String messageText);
+extern bool batteryVoltageAvailable;
+extern bool internetAvailable;
+
+// Post a dweet to report the various sensor readings.  This routine blocks while
+// talking to the network, so may take a while to execute.
+void post_dweet(uint16_t co2, float tempF, float humidity, float battv, int rssi)
+{
+  String dweeturl = "http://" + String(DWEET_HOST) + "/dweet/for/" + String(DWEET_DEVICE);
+
+  // If no Internet, return
+  if(!internetAvailable) return(void ());
+
+  WiFiClient dweet_client;
+
+  // Transmit Dweet as HTTP post with a data payload as JSON
+  String device_info = "{\"rssi\":\""   + String(rssi)               + "\"," +
+                        "\"ipaddr\":\"" + WiFi.localIP().toString()  + "\",";
+  
+  String battery_info;
+  if(batteryVoltageAvailable) {
+    battery_info = "\"battery_voltage\":\"" + String(battv)   + "\",";
+  }
+  else {
+    battery_info = "";
+  }
+
+  String sensor_info;
+  sensor_info = "\"co2\":\""         + String(co2)             + "\"," +
+                "\"temperature\":\"" + String(tempF, 2)        + "\"," +
+                "\"humidity\":\""    + String(humidity, 2)     + "\"}";
+
+  String postdata = device_info + battery_info + sensor_info;
+
+  // Note that the dweet device 'name' gets set here, is needed to fetch values
+  dweet_client.println("POST /dweet/for/" + String(DWEET_DEVICE) + " HTTP/1.1");
+  dweet_client.println("Host: dweet.io");
+  dweet_client.println("User-Agent: ESP32/ESP8266 (orangemoose)/1.0");
+  dweet_client.println("Cache-Control: no-cache");
+  dweet_client.println("Content-Type: application/json");
+  dweet_client.print("Content-Length: ");
+  dweet_client.println(postdata.length());
+  dweet_client.println();
+  dweet_client.println(postdata);
+  debugMessage("Dweet POST:");
+  debugMessage(postdata);
+
+  delay(1500);  
+
+  // Read all the lines of the reply from server (if any) and print them to Serial Monitor
+  #ifdef DEBUG
+    debugMessageln("Dweet server response:");
+    while(dweet_client.available()){
+      String line = dweet_client.readStringUntil('\r');
+      debugMessage(line);
+    }
+    debugMessageln("-----");
+  #endif
+  
+  // Close client connection to dweet server
+  dweet_client.stop();
+}
+#endif

--- a/post_influx.cpp
+++ b/post_influx.cpp
@@ -9,6 +9,8 @@
 
 // hardware and internet configuration parameters
 #include "config.h"
+// Overall data and metadata naming scheme
+#include "data.h"
 // private credentials for network, MQTT, weather provider
 #include "secrets.h"
 
@@ -52,13 +54,15 @@
     // Add constant Influx data point tags - only do once, will be added to all individual data points
     // Modify if required to reflect your InfluxDB data model (and set values in config.h)
     // First for environmental data
-    dbenvdata.addTag("device", DEVICE_TYPE);
-    dbenvdata.addTag("location", DEVICE_LOCATION);
-    dbenvdata.addTag("site", DEVICE_SITE);
+    dbenvdata.addTag(TAG_KEY_DEVICE, DEVICE);
+    dbenvdata.addTag(TAG_KEY_SITE, DEVICE_SITE);
+    dbenvdata.addTag(TAG_KEY_LOCATION, DEVICE_LOCATION);
+    dbenvdata.addTag(TAG_KEY_ROOM, DEVICE_ROOM);
     // And again for device data
-    dbdevdata.addTag("device", DEVICE_TYPE);
-    dbdevdata.addTag("location", DEVICE_LOCATION);
-    dbdevdata.addTag("site", DEVICE_SITE);
+    dbdevdata.addTag(TAG_KEY_DEVICE, DEVICE);
+    dbdevdata.addTag(TAG_KEY_SITE, DEVICE_SITE);
+    dbdevdata.addTag(TAG_KEY_LOCATION, DEVICE_LOCATION);
+    dbdevdata.addTag(TAG_KEY_ROOM, DEVICE_ROOM);
 
     // Attempts influxDB connection, and if unsuccessful, re-attempts after CONNECT_ATTEMPT_INTERVAL second delay for CONNECT_ATTEMPT_LIMIT times
     for (int tries = 1; tries <= CONNECT_ATTEMPT_LIMIT; tries++) {
@@ -75,9 +79,9 @@
       // Connected, so store sensor values into timeseries data point
       dbenvdata.clearFields();
       // Report sensor readings
-      dbenvdata.addField("tempF", tempF);
-      dbenvdata.addField("humidity", humidity);
-      dbenvdata.addField("co2", co2);
+      dbenvdata.addField(VALUE_KEY_TEMPERATURE, tempF);
+      dbenvdata.addField(VALUE_KEY_HUMIDITY, humidity);
+      dbenvdata.addField(VALUE_KEY_CO2, co2);
       // Write point via connection to InfluxDB host
       if (!dbclient.writePoint(dbenvdata)) {
         debugMessage("InfluxDB write failed: " + dbclient.getLastErrorMessage());
@@ -92,9 +96,9 @@
       dbdevdata.clearFields();
       // Report device readings
       if (batteryVoltage > 0)
-        dbdevdata.addField("battery_volts", batteryVoltage);
+        dbdevdata.addField(VALUE_KEY_BATTERY_VOLTS, batteryVoltage);
       if (rssi>0)
-        dbdevdata.addField("rssi", rssi);
+        dbdevdata.addField(VALUE_KEY_RSSI, rssi);
       if ((batteryVoltage>0) || (rssi>0))
       {
         if (!dbclient.writePoint(dbdevdata))

--- a/post_mqtt.cpp
+++ b/post_mqtt.cpp
@@ -37,7 +37,7 @@ extern void debugMessage(String messageText, int messageLevel);
     {
       if ((mqttErr = aq_mqtt.connect()) == 0)
       {
-        debugMessage(String("Connected to MQTT broker ") + MQTT_BROKER);
+        debugMessage(String("Connected to MQTT broker ") + MQTT_BROKER,1);
         return;
       }
       // Adafruit IO connect errors
@@ -64,7 +64,7 @@ extern void debugMessage(String messageText, int messageLevel);
     String topic;
     topic = String(DEVICE_SITE) + "/" + String(DEVICE_LOCATION) + "/" + String(DEVICE_ROOM) +
             "/" + String(DEVICE) + "/" + String(key);
-    debugMessage(String("Generated MQTT topic: ") + topic);
+    debugMessage(String("Generated MQTT topic: ") + topic,2);
     return(topic);
   }
 

--- a/post_mqtt.cpp
+++ b/post_mqtt.cpp
@@ -2,6 +2,8 @@
 
 // hardware and internet configuration parameters
 #include "config.h"
+// Overall data and metadata naming scheme
+#include "data.h"
 // private credentials for network, MQTT, weather provider
 #include "secrets.h"
 
@@ -55,13 +57,26 @@ extern void debugMessage(String messageText);
     }
   } 
 
+  // Utility function to streamline dynamically generating MQTT topics using site and device 
+  // parameters defined in config.h and our standard naming scheme using values set in data.h
+  String generateTopic(char *key)
+  {
+    String topic;
+    topic = String(DEVICE_SITE) + "/" + String(DEVICE_LOCATION) + "/" + String(DEVICE_ROOM) +
+            "/" + String(DEVICE) + "/" + String(key);
+    debugMessage(String("Generated MQTT topic: ") + topic);
+    return(topic);
+  }
+
   int mqttDeviceBatteryUpdate(float batteryVoltage)
   {
     bool result = false;
     if (batteryVoltage > 0)
     {
+      String topic;
+      topic = generateTopic(VALUE_KEY_BATTERY_VOLTS);  // Generate topic using config.h and data.h parameters
       // add ,MQTT_QOS_1); if problematic, remove QOS parameter
-      Adafruit_MQTT_Publish batteryVoltagePub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_BATTVOLT);
+      Adafruit_MQTT_Publish batteryVoltagePub = Adafruit_MQTT_Publish(&aq_mqtt,topic.c_str());
       mqttConnect();
 
       // publish battery voltage
@@ -83,8 +98,10 @@ extern void debugMessage(String messageText);
     int result = 0;
     if (rssi!=0)
     {
+      String topic;
+      topic = generateTopic(VALUE_KEY_RSSI);  // Generate topic using config.h and data.h parameters
       // add ,MQTT_QOS_1); if problematic, remove QOS parameter
-      Adafruit_MQTT_Publish rssiLevelPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_RSSI);
+      Adafruit_MQTT_Publish rssiLevelPub = Adafruit_MQTT_Publish(&aq_mqtt, topic.c_str());
       
       mqttConnect();
 
@@ -105,8 +122,10 @@ extern void debugMessage(String messageText);
   // Publishes temperature data to MQTT broker
   {
     bool result = false;
+    String topic;
+    topic = generateTopic(VALUE_KEY_TEMPERATURE);  // Generate topic using config.h and data.h parameters
     // add ,MQTT_QOS_1); if problematic, remove QOS parameter
-    Adafruit_MQTT_Publish tempPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_TEMPF);
+    Adafruit_MQTT_Publish tempPub = Adafruit_MQTT_Publish(&aq_mqtt, topic.c_str());
     
     mqttConnect();
 
@@ -126,8 +145,10 @@ extern void debugMessage(String messageText);
   // Publishes humidity data to MQTT broker
   {
     bool result = false;
+    String topic;
+    topic = generateTopic(VALUE_KEY_HUMIDITY);  // Generate topic using config.h and data.h parameters
     // add ,MQTT_QOS_1); if problematic, remove QOS parameter
-    Adafruit_MQTT_Publish humidityPub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_HUMIDITY);
+    Adafruit_MQTT_Publish humidityPub = Adafruit_MQTT_Publish(&aq_mqtt, topic.c_str());
     
     mqttConnect();
     
@@ -147,8 +168,10 @@ extern void debugMessage(String messageText);
   // Publishes CO2 data to MQTT broker
   {
     bool result = false;
+    String topic;
+    topic = generateTopic(VALUE_KEY_CO2);  // Generate topic using config.h and data.h parameters
     // add ,MQTT_QOS_1); if problematic, remove QOS parameter
-    Adafruit_MQTT_Publish co2Pub = Adafruit_MQTT_Publish(&aq_mqtt, MQTT_PUB_CO2);   
+    Adafruit_MQTT_Publish co2Pub = Adafruit_MQTT_Publish(&aq_mqtt, topic.c_str());   
     
     mqttConnect();
 

--- a/realtime_co2.ino
+++ b/realtime_co2.ino
@@ -646,7 +646,7 @@ void networkDisconnect()
 {
   #if defined(MQTT) || defined(INFLUX) || defined(HASSIO_MQTT)
   {
-    W609i.disconnect();
+    WiFi.disconnect();
     debugMessage("Disconnected from WiFi network",1);
   }
   #endif

--- a/realtime_co2.ino
+++ b/realtime_co2.ino
@@ -86,7 +86,7 @@ const int sparklineHeight = 40;
 
   #include <Adafruit_MQTT.h>
   #include <Adafruit_MQTT_Client.h>
-  Adafruit_MQTT_Client aq_mqtt(&client, MQTT_BROKER, MQTT_PORT, CLIENT_ID, MQTT_USER, MQTT_PASS);
+  Adafruit_MQTT_Client aq_mqtt(&client, MQTT_BROKER, MQTT_PORT, DEVICE_ID, MQTT_USER, MQTT_PASS);
 
   extern bool mqttDeviceWiFiUpdate(int rssi);
   extern bool mqttDeviceBatteryUpdate(float batteryVoltage);
@@ -109,7 +109,7 @@ void setup()
     debugMessage("realtime co2 monitor started");
     debugMessage("---------------------------------");
     debugMessage(String(SAMPLE_INTERVAL) + " second sample interval");
-    debugMessage("Client ID: " + String(CLIENT_ID));
+    debugMessage("Device (Client) ID: " + String(DEVICE_ID));
   #endif
 
   hardwareData.batteryVoltage = 0;  // 0 = no battery attached
@@ -615,7 +615,7 @@ bool networkConnect()
 {
   #ifdef WIFI
     // set hostname has to come before WiFi.begin
-    WiFi.hostname(CLIENT_ID);
+    WiFi.hostname(DEVICE_ID);
 
     WiFi.begin(WIFI_SSID, WIFI_PASS);
 

--- a/realtime_co2.ino
+++ b/realtime_co2.ino
@@ -77,6 +77,10 @@ const int ytemp = 170;
 const int yMessage = display.height()- 9;
 const int sparklineHeight = 40;
 
+#ifdef DWEET
+  extern void post_dweet(uint16_t co2, float tempF, float humidity, float battv, int rssi);
+#endif 
+
 #ifdef INFLUX
   extern boolean post_influx(uint16_t co2, float tempF, float humidity, float batteryVoltage, int rssi);
 #endif
@@ -173,6 +177,11 @@ void setup()
       {
         upd_flags += "I";
       }
+    #endif
+
+    #ifdef DWEET
+      // Fire and forget posting of device & sensor status via Dweet.io (no update flags)
+      post_dweet(sensorData.ambientCO2, sensorData.ambientTempF, sensorData.ambientHumidity, hardwareData.batteryVoltage, hardwareData.rssi);
     #endif
 
     if (upd_flags == "") 
@@ -618,7 +627,7 @@ void nvStorageWrite(int storedCounter)
 bool networkConnect()
 {
   // Run only if using network data endpoints
-  #if defined(MQTT) || defined(INFLUX) || defined(HASSIO_MQTT)
+  #if defined(MQTT) || defined(INFLUX) || defined(HASSIO_MQTT) || defined(DWEET)
     // set hostname has to come before WiFi.begin
     WiFi.hostname(DEVICE_ID);
 


### PR DESCRIPTION
Up to now we've been using explicit #defines in config.h to specific naming schemes for back end data services, allowing flexibility setting tag and field keys/values for Influx, topics for MQTT, device identification for integration with Home Assistant, etc.   However, those naming schemes are customized per device and per deployment, and with the increase in service integrations and a broader range of devices derived from a common code base it has become increasingly tedious to find and set all the various service-specific parameters at deployment time.

This pull release introduces a single scheme for defining device, data, and deployment settings.  Those values are configured once in a (new) data.h header file, which all back end service integrations use to derive their reporting schema.  This makes deployments much easier in the current compile-time binding scheme and also sets the stage for run-time configurability when we're ready to add that capability.  Other important configuration settings are still to be found in config.h, and secret/private information in secrets.h.  In some cases, e.g. MQTT topic definition, back end service parameters are generated at run time in the relevant service routine (e.g. post_mqtt()) rather than having them appear as pre-defined (complie time) values in config.h.  This is highlighted in comments in the code at the appropriate places.

This pull request is three commits behind the current main branch due to parallel development, and some merge conflicts are known to exist.  Resolving those conflicts and then testing the consolidated code in this branch will be necessary before actually merging this branch into main.