### PR TITLE
Gxpepd2 support

### DIFF
--- a/config.h
+++ b/config.h
@@ -57,12 +57,16 @@ const int   batteryReads = 5;
 #define CONNECT_ATTEMPT_LIMIT	3 // max connection attempts to internet services
 #define CONNECT_ATTEMPT_INTERVAL 10 // seconds between internet service connect attempts
 
-// Pin config for host board to Adafruit 1.54" 200x200 EPD
+// Pin config for host board to 1.54" 200x200 EPD
 #define EPD_CS      12
 #define EPD_DC      27
-#define SRAM_CS     14 // can set to -1 to not use a pin (uses a lot of RAM!)
-#define EPD_RESET   15 // can set to -1 and share with chip Reset (can't deep sleep)
-#define EPD_BUSY    32 // can set to -1 to not use a pin (will wait a fixed delay)
+//#define SRAM_CS     14
+#define EPD_RESET   15
+#define EPD_BUSY    32
+
+// base class GxEPD2_GFX can be used to pass references or pointers to the display instance as parameter, uses ~1.2k more code
+// enable GxEPD2_GFX base class
+#define ENABLE_GxEPD2_GFX 1
 
 // Allow for adjustable screen as needed for physical packaging. 
 // rotation 1 orients the display so the wiring is at the top
@@ -73,8 +77,8 @@ const int   batteryReads = 5;
 #ifdef DEBUG
 	// number of times SCD40 is read, last read is the sample value
 	#define READS_PER_SAMPLE	1
-	// time between samples in seconds. Must be >=180 to protect EPD
-	#define SAMPLE_INTERVAL		180
+	// time between samples in seconds. Must be >=180 to protect 3 color EPD
+	#define SAMPLE_INTERVAL		60
 #else
 	#define READS_PER_SAMPLE	3
 	#define SAMPLE_INTERVAL 	180

--- a/config.h
+++ b/config.h
@@ -10,7 +10,7 @@
 
 // Configuration Step 2: Set debug message output
 // comment out to turn off; 1 = summary, 2 = verbose
-#define DEBUG 1
+#define DEBUG 0
 
 // Configuration Step 3: Set network data endpoints
 // #define MQTT 		    // log sensor data to M/QTT broker
@@ -69,9 +69,8 @@ const int   batteryReads = 5;
 #define ENABLE_GxEPD2_GFX 1
 
 // Allow for adjustable screen as needed for physical packaging. 
-// rotation 1 orients the display so the wiring is at the top
-// rotation of 3 flips it so the wiring is at the bottom
-#define DISPLAY_ROTATION 1
+// rotation 0 orients as "top" near flex cable
+#define DISPLAY_ROTATION 0
 
 // SCD40 sample timing
 #ifdef DEBUG

--- a/data.h
+++ b/data.h
@@ -23,7 +23,7 @@
 // as parts of MQTT topics.  Must be unique, and must conform
 // to syntax required for field keys by InfluxDB and MQTT.
 
-#define VALUE_KEY_TEMPERATURE     "temperature"
+#define VALUE_KEY_TEMPERATURE     "tempF"
 #define VALUE_KEY_HUMIDITY        "humidity"
 #define VALUE_KEY_CO2             "co2"
 // #define VALUE_KEY_PRESSURE     "pressure"

--- a/post_influx.cpp
+++ b/post_influx.cpp
@@ -66,7 +66,7 @@
     // Attempts influxDB connection, and if unsuccessful, re-attempts after CONNECT_ATTEMPT_INTERVAL second delay for CONNECT_ATTEMPT_LIMIT times
     for (int tries = 1; tries <= CONNECT_ATTEMPT_LIMIT; tries++) {
       if (dbclient.validateConnection()) {
-        debugMessage(String("Connected to InfluxDB: ") + dbclient.getServerUrl(),1);
+        debugMessage(String("Connected to InfluxDB: ") + dbclient.getServerUrl(),2);
         result = true;
         break;
       }

--- a/realtime_co2.ino
+++ b/realtime_co2.ino
@@ -116,7 +116,7 @@ void setup()
     while (!Serial);
   #endif
 
-  debugMessage("realtime co2 monitor started",1);
+  debugMessage("realtime_co2 started",1);
   debugMessage("Device ID: " + String(DEVICE_ID),1);
   debugMessage(String(SAMPLE_INTERVAL) + " second sample interval",2);
 
@@ -264,8 +264,8 @@ void screenInfo(String messageText)
   {
     display.fillScreen(GxEPD_WHITE);
     // screen helper routines
-    // display battery level in the upper right corner
-    screenHelperBatteryStatus((display.width()-xMargins-batteryBarWidth),yMargins,batteryBarWidth, batteryBarHeight);
+    // display battery level in the upper right corner, -3 in first parameter accounts for battery nub
+    screenHelperBatteryStatus((display.width()-xMargins-batteryBarWidth-3),yMargins,batteryBarWidth, batteryBarHeight);
 
     // display wifi status left offset to the battery level indicator
     screenHelperWiFiStatus((display.width() - 35), (display.height() - yMargins),wifiBarWidth,wifiBarHeightIncrement,wifiBarSpacing);
@@ -386,7 +386,6 @@ int batteryGetChargeLevel(float volts)
       break;
     }
   }
-  debugMessage(String("Battery percentage as int is ")+idx+"%",1);
   return idx;
 }
 
@@ -398,15 +397,15 @@ void screenHelperBatteryStatus(int initialX, int initialY, int barWidth, int bar
   if (hardwareData.batteryVoltage>0) 
   {
     // battery nub; width = 3pix, height = 60% of barHeight
-    display.fillRect((initialX+barWidth-3), (initialY+(int(barHeight/5))), 3, (int(barHeight*3/5)), GxEPD_BLACK);
+    display.fillRect((initialX+barWidth), (initialY+(int(barHeight/5))), 3, (int(barHeight*3/5)), GxEPD_BLACK);
     // battery border
     display.drawRect(initialX, initialY, barWidth, barHeight, GxEPD_BLACK);
     //battery percentage as rectangle fill, 1 pixel inset from the battery border
     display.fillRect((initialX + 2), (initialY + 2), int(0.5+(hardwareData.batteryPercent*((barWidth-4)/100.0))), (barHeight - 4), GxEPD_BLACK);
-    debugMessage(String("battery percent visualized=") + hardwareData.batteryPercent + "%, " + int(0.5+(hardwareData.batteryPercent*((barWidth-4)/100.0))) + " pixels of " + (barWidth-4) + " max",1);
+    debugMessage(String("battery: ") + hardwareData.batteryPercent + "%, " + int(0.5+(hardwareData.batteryPercent*((barWidth-4)/100.0))) + " of " + (barWidth-4) + " pixels",1);
   }
   else
-    debugMessage("No battery voltage for screenHelperBatteryStatus() to render",1);
+    debugMessage("No battery voltage for screenHelperBatteryStatus to render",1);
 }
 
 void screenHelperSparkLine(int xStart, int yStart, int xWidth, int yHeight)
@@ -431,11 +430,11 @@ void screenHelperSparkLine(int xStart, int yStart, int xWidth, int yHeight)
     if(co2Samples[i] > co2Max) co2Max = co2Samples[i];
     if(co2Samples[i] < co2Min) co2Min = co2Samples[i];
   }
-  debugMessage(String("Max CO2 in stored sample range is ") + co2Max +", min is " + co2Min,2);
+  debugMessage(String("Max CO2 in stored sample range: ") + co2Max +", min: " + co2Min,2);
  
   // vertical distance (pixels) between each displayed co2 value
   yPixelStep = round(((co2Max - co2Min) / yHeight)+.5);
-  debugMessage(String("xPixelStep is ") + xPixelStep + ", yPixelStep is " + yPixelStep,2);
+  debugMessage(String("xPixelStep: ") + xPixelStep + ", yPixelStep: " + yPixelStep,2);
 
   // sparkline border box (if needed)
   //display.drawRect(xMargins,ySparkline, ((display.width()) - (2 * xMargins)),sparklineHeight, GxEPD_BLACK);
@@ -451,7 +450,7 @@ void screenHelperSparkLine(int xStart, int yStart, int xWidth, int yHeight)
   }
   for (int i=0;i<co2MaxStoredSamples;i++)
   {
-    debugMessage(String("X,Y coordinates for CO2 sample ") + i + " is " + sparkLineX[i] + "," + sparkLineY[i],2);
+    debugMessage(String("X,Y coordinates for CO2 sample ") + i + ": " + sparkLineX[i] + "," + sparkLineY[i],2);
   }
     debugMessage("sparkline drawn to screen",2);
 }
@@ -517,7 +516,7 @@ bool sensorCO2Init() {
   } 
   else
   {
-    debugMessage("SCD40 initialized",2);
+    debugMessage("power on: SCD40",1);
     return true;
   }
 }
@@ -553,12 +552,13 @@ bool sensorCO2Read()
 
 void powerEnable()
 {
+  debugMessage("powerEnable started",1);
+
   // Handle two ESP32 I2C ports
   #if defined(ARDUINO_ADAFRUIT_QTPY_ESP32S2) || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM) || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3) || defined(ARDUINO_ADAFRUIT_QTPY_ESP32_PICO)
-    // ESP32 is kinda odd in that secondary ports must be manually
-    // assigned their pins with setPins()!
+    // ESP32 is kinda odd in that secondary ports must be manually assigned their pins with setPins()!
     Wire1.setPins(SDA1, SCL1);
-    debugMessage("enabled ESP32 hardware with two I2C ports",2);
+    debugMessage("power on: ESP32 hardware with two I2C ports",2);
   #endif
 
   // Adafruit ESP32 I2C power management
@@ -575,7 +575,7 @@ void powerEnable()
     // if you need to turn the neopixel on
     // pinMode(NEOPIXEL_POWER, OUTPUT);
     // digitalWrite(NEOPIXEL_POWER, HIGH);
-    debugMessage("enabled Adafruit Feather ESP32S2 I2C power",1);
+    debugMessage("power on: Feather ESP32S2 I2C",1);
   #endif
 
   #if defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2_TFT)
@@ -591,18 +591,18 @@ void powerEnable()
     // Turn on neopixel
     // pinMode(NEOPIXEL_POWER, OUTPUT);
     // digitalWrite(NEOPIXEL_POWER, HIGH);
-    debugMessage("enabled Adafruit Feather ESP32 V2 I2C power",1);
+    debugMessage("power on: Feather ESP32V2 I2C",1);
   #endif
 }
 
 void powerDisable(int deepSleepTime)
 // Powers down hardware in preparation for board deep sleep
 {
-  debugMessage("Starting power down activities",1);
+  debugMessage("powerDisable started",1);
   
   // power down epd
   display.powerOff();
-  debugMessage("powered down epd",1);
+  debugMessage("power off: EPD",1);
 
   networkDisconnect();
 
@@ -616,7 +616,7 @@ void powerDisable(int deepSleepTime)
     debugMessage(String(errorMessage) + " executing SCD40 stopPeriodicMeasurement()",1);
   }
   envSensor.powerDown();
-  debugMessage("SCD40 powered down",1);
+  debugMessage("power off: SCD40",1);
 
   #if defined(ARDUINO_ADAFRUIT_FEATHER_ESP32_V2)
     // Turn off the I2C power
@@ -626,7 +626,7 @@ void powerDisable(int deepSleepTime)
     // if you need to turn the neopixel off
     // pinMode(NEOPIXEL_POWER, OUTPUT);
     // digitalWrite(NEOPIXEL_POWER, LOW);
-    debugMessage("disabled Adafruit Feather ESP32 V2 I2C power",1);
+    debugMessage("power off: ESP32V2 I2C",1);
   #endif
 
   #if defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
@@ -637,11 +637,11 @@ void powerDisable(int deepSleepTime)
     // if you need to turn the neopixel off
     // pinMode(NEOPIXEL_POWER, OUTPUT);
     // digitalWrite(NEOPIXEL_POWER, LOW);
-    debugMessage("disabled Adafruit Feather ESP32S2 I2C power",1);
+    debugMessage("power off: ESP32S2 I2C",1);
   #endif
 
   esp_sleep_enable_timer_wakeup(deepSleepTime*1000000); // ESP microsecond modifier
-  debugMessage(String("Starting ESP32 deep sleep for ") + (deepSleepTime) + " seconds",1);
+  debugMessage(String("powerDisable complete: ESP32 deep sleep for ") + (deepSleepTime) + " seconds",1);
   esp_deep_sleep_start();
 }
 
@@ -675,7 +675,7 @@ int nvStorageRead()
     nvStoreBaseName = "co2Sample" + String(i);
     // get previously stored values. If they don't exist, create them as 400 (CO2 floor)
     co2Samples[i] = nvStorage.getLong(nvStoreBaseName.c_str(),400);
-    debugMessage(String(nvStoreBaseName) + " retrieved from nv storage is " + co2Samples[i],2);
+    debugMessage(String(nvStoreBaseName) + " retrieved from nv storage: " + co2Samples[i],2);
   }
   return storedCounter;
 }
@@ -705,8 +705,9 @@ bool networkConnect()
       if (WiFi.status() == WL_CONNECTED)
       {
         hardwareData.rssi = abs(WiFi.RSSI());
-        debugMessage(String("WiFi IP address lease from ") + WIFI_SSID + " is " + WiFi.localIP().toString(),1);
-        debugMessage(String("WiFi RSSI is: ") + hardwareData.rssi + " dBm",1);
+        debugMessage("power on: WiFi",1);
+        debugMessage(String("WiFi IP address from ") + WIFI_SSID + ": " + WiFi.localIP().toString(),1);
+        debugMessage(String("WiFi RSSI: ") + hardwareData.rssi + " dBm",1);
         return true;
       }
       debugMessage(String("Connection attempt ") + tries + " of " + CONNECT_ATTEMPT_LIMIT + " to " + WIFI_SSID + " failed",1);
@@ -723,7 +724,7 @@ void networkDisconnect()
   {
     WiFi.disconnect();
     WiFi.mode(WIFI_OFF);
-    debugMessage("Disconnected from WiFi network",1);
+    debugMessage("power off: WiFi",1);
   }
   #endif
 }
@@ -751,7 +752,7 @@ void setTimeZone(String timezone)
   debugMessage(String("setting Timezone to ") + timezone.c_str(),2);
   setenv("TZ",timezone.c_str(),1);
   tzset();
-  debugMessage(String("Local time is: ") + dateTimeString("short"),1);
+  debugMessage(String("Local time: ") + dateTimeString("short"),1);
 }
 
 // Converts time into human readable strings

--- a/realtime_co2.ino
+++ b/realtime_co2.ino
@@ -598,9 +598,7 @@ void powerDisable(int deepSleepTime)
 
   networkDisconnect();
 
-  // power down SCD40
-
-  // stops potentially started measurement then powers down SCD40
+  // power down SCD40 by stopping potentially started measurement then power down SCD40
   uint16_t error = envSensor.stopPeriodicMeasurement();
   if (error) {
     char errorMessage[256];
@@ -614,10 +612,6 @@ void powerDisable(int deepSleepTime)
     // Turn off the I2C power
     pinMode(NEOPIXEL_I2C_POWER, OUTPUT);
     digitalWrite(NEOPIXEL_I2C_POWER, LOW);
-
-    // if you need to turn the neopixel off
-    // pinMode(NEOPIXEL_POWER, OUTPUT);
-    // digitalWrite(NEOPIXEL_POWER, LOW);
     debugMessage("power off: ESP32V2 I2C",1);
   #endif
 
@@ -625,10 +619,6 @@ void powerDisable(int deepSleepTime)
     // Rev B board is LOW to enable
     // Rev C board is HIGH to enable
     digitalWrite(PIN_I2C_POWER, LOW);
-
-    // if you need to turn the neopixel off
-    // pinMode(NEOPIXEL_POWER, OUTPUT);
-    // digitalWrite(NEOPIXEL_POWER, LOW);
     debugMessage("power off: ESP32S2 I2C",1);
   #endif
 

--- a/realtime_co2.ino
+++ b/realtime_co2.ino
@@ -116,13 +116,12 @@ void setup()
     while (!Serial);
   #endif
 
-  debugMessage("realtime_co2 started",1);
-  debugMessage("Device ID: " + String(DEVICE_ID),1);
+  debugMessage("realtime_co2 Device ID: " + String(DEVICE_ID),1);
   debugMessage(String(SAMPLE_INTERVAL) + " second sample interval",2);
 
   hardwareData.rssi = 0;  // 0 = no WiFi 
 
-  powerEnable();
+  powerI2CEnable();
 
   // initiate first to display hardware error messages
   //display.init(115200); // default 10ms reset pulse, e.g. for bare panels with DESPI-C02
@@ -550,15 +549,16 @@ bool sensorCO2Read()
   return true;
 }
 
-void powerEnable()
+void powerI2CEnable()
+// enables I2C across multiple Adafruit ESP32 variants
 {
   debugMessage("powerEnable started",1);
 
-  // Handle two ESP32 I2C ports
+  // enable I2C on devices with two ports
   #if defined(ARDUINO_ADAFRUIT_QTPY_ESP32S2) || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM) || defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3) || defined(ARDUINO_ADAFRUIT_QTPY_ESP32_PICO)
     // ESP32 is kinda odd in that secondary ports must be manually assigned their pins with setPins()!
     Wire1.setPins(SDA1, SCL1);
-    debugMessage("power on: ESP32 hardware with two I2C ports",2);
+    debugMessage("power on: ESP32 variant with two I2C ports",2);
   #endif
 
   // Adafruit ESP32 I2C power management
@@ -571,10 +571,6 @@ void powerEnable()
     bool polarity = digitalRead(PIN_I2C_POWER);
     pinMode(PIN_I2C_POWER, OUTPUT);
     digitalWrite(PIN_I2C_POWER, !polarity);
-
-    // if you need to turn the neopixel on
-    // pinMode(NEOPIXEL_POWER, OUTPUT);
-    // digitalWrite(NEOPIXEL_POWER, HIGH);
     debugMessage("power on: Feather ESP32S2 I2C",1);
   #endif
 
@@ -587,10 +583,6 @@ void powerEnable()
     // Turn on the I2C power
     pinMode(NEOPIXEL_I2C_POWER, OUTPUT);
     digitalWrite(NEOPIXEL_I2C_POWER, HIGH);
-
-    // Turn on neopixel
-    // pinMode(NEOPIXEL_POWER, OUTPUT);
-    // digitalWrite(NEOPIXEL_POWER, HIGH);
     debugMessage("power on: Feather ESP32V2 I2C",1);
   #endif
 }
@@ -602,7 +594,7 @@ void powerDisable(int deepSleepTime)
   
   // power down epd
   display.powerOff();
-  debugMessage("power off: EPD",1);
+  debugMessage("power off: epd",1);
 
   networkDisconnect();
 
@@ -731,7 +723,7 @@ void networkDisconnect()
 
 bool networkGetTime(String timezone)
 {
-  https://randomnerdtutorials.com/esp32-ntp-timezones-daylight-saving/
+  // https://randomnerdtutorials.com/esp32-ntp-timezones-daylight-saving/
 
   struct tm timeinfo;
 


### PR DESCRIPTION
Transitioning from Adafruit EPD library to GxEPDv2 library. This change has been tested on the current Adafruit 1.54" mono EPD and bare Waveshare 1.54" V2 mono EPDs. Numerous debug message changes to improve readability. Also fixes one visual bug with the battery display function.